### PR TITLE
Fix to run with Python 3.8.1

### DIFF
--- a/copycat/gui/status.py
+++ b/copycat/gui/status.py
@@ -1,6 +1,6 @@
 import matplotlib
 matplotlib.use("TkAgg")
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 
 import tkinter as tk


### PR DESCRIPTION
NavigationToolbar2TkAgg is not available/used any more, so I needed to make this change. Perhaps you will also need to do same? Here is the command I used to run the program and the output...

➜  mmcg-copycat git:(python3-tk-nav-toolbar-fix) python3 main.py aabc aabd ijkk --iterations 10
Changing to adjustment formula pbest
Answered ijkl (time 1377, final temperature 14.0)
Answered ijkl (time 2407, final temperature 18.1)
Answered ijll (time 3830, final temperature 24.7)
Answered ijkl (time 10210, final temperature 46.0)
Answered ijll (time 11434, final temperature 41.1)
Answered ijkl (time 13563, final temperature 27.8)
Answered ijkl (time 14477, final temperature 15.1)
Answered ijkl (time 15917, final temperature 74.7)
Answered ijll (time 19192, final temperature 38.1)
Answered ijll (time 20163, final temperature 54.0)
The formula pbest provided:
Average difference: 0.058909952593069706
ijkl: 6 (avg time 9658.5, avg temp 32.6)
ijll: 4 (avg time 13654.8, avg temp 39.5)